### PR TITLE
Do not display number of messages in quota

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -82,10 +82,7 @@ const Contact = () => {
       if (data.success) {
         toast({
           title: "Message sent!",
-          description:
-            data.remainingAttempts > 0
-              ? `We'll get back to you as soon as possible. You have ${data.remainingAttempts} messages remaining.`
-              : "We'll get back to you as soon as possible.",
+          description: "We'll get back to you as soon as possible.",
         });
         setFormData({
           name: "",


### PR DESCRIPTION
When sending messages from the contact form you get notified how many are remaining within the rate limited hourly quota.

No one wants to know that they are limited - no one will exceed the quota anyway, and if they do they already get told how to resolve the issue.

People just want to know their message was sent.

Remove the counter display.