### PR TITLE
chore(ui): Simplify success toast by removing remaining message count

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -82,10 +82,7 @@ const Contact = () => {
       if (data.success) {
         toast({
           title: "Message sent!",
-          description:
-            data.remainingAttempts > 0
-              ? `We'll get back to you as soon as possible. You have ${data.remainingAttempts} messages remaining.`
-              : "We'll get back to you as soon as possible.",
+          description: "We'll get back to you as soon as possible.",
         });
         setFormData({
           name: "",


### PR DESCRIPTION
## Description
This PR updates the success toast shown after submitting the contact form. Previously, the toast conditionally displayed how many message attempts remained. This logic has been removed to simplify the UI and avoid showing quota-related details to the user.

## Testing Checklist
- [x] Toast message displays correctly after form submission  
- [x] No references to `remainingAttempts` in UI  
- [x] Contact form still resets on success  